### PR TITLE
fix error poetry add

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
-[tool.poetry]
+[project]
 name = "dggrid4py"
 version = "0.5.0-dev"
 description = "a Python library to run highlevel functions of DGGRIDv7 and v8"
-authors = ["Alexander Kmoch <alexander.kmoch@ut.ee>",
-    "Wai Tik Chan <wai.tik.chan@ut.ee>",
-    "Luís Moreira de Sousa <luis.de.sousa@protonmail.ch>"]
+authors = [
+  { name = "Alexander Kmoch", email = "alexander.kmoch@ut.ee" },
+  { name = "Wai Tik Chan", email = "wai.tik.chan@ut.ee>" },
+  { name = "Luís Moreira de Sousa", email = "luis.de.sousa@protonmail.ch" },
+  { name = "Francis Charette-Migneault", email = "francis.charette-migneault@crim.ca" }
+]
 license = "AGPL-3.0-or-later"
 readme = "README.md"
 repository = "https://github.com/allixender/dggrid4py"


### PR DESCRIPTION
When interacting with `poetry`, the current `pyproject.toml` is considered invalid. 
This fixes the definition to allow `poetry add ...` to work. 