### PR TITLE
new function to support conversion from z7string to z7 interger

### DIFF
--- a/dggrid4py/dggrid_runner.py
+++ b/dggrid4py/dggrid_runner.py
@@ -531,6 +531,7 @@ class Dggs:
     pole_lat_deg: DggsDegree = 58.28252559
     pole_lon_deg: DggsDegree = 11.25
     mixed_aperture_level: int | None = None
+    clipper_scale_factor: float = 1000000
 
     _hide_metafile = [
         'metric',

--- a/dggrid4py/dggrid_runner.py
+++ b/dggrid4py/dggrid_runner.py
@@ -531,7 +531,6 @@ class Dggs:
     pole_lat_deg: DggsDegree = 58.28252559
     pole_lon_deg: DggsDegree = 11.25
     mixed_aperture_level: int | None = None
-    clipper_scale_factor: float = 1000000
 
     _hide_metafile = [
         'metric',

--- a/dggrid4py/igeo7.py
+++ b/dggrid4py/igeo7.py
@@ -75,6 +75,15 @@ def z7int_to_z7hex(z7_int):
 
 
 def z7string_to_z7int(z7string):
+    """
+    Convert z7string to z7int. Inverse of decode_z7hex_index
+
+    Args:
+        z7string (str): The z7 digits representation of zone ID
+
+    Returns:
+        int: integer representation of the z7 string.
+    """
     base, digit = z7string[:2], z7string[2:]
     digit = digit.ljust(20, '7')
     binary_repr = [np.binary_repr(int(base), width=4)]

--- a/dggrid4py/igeo7.py
+++ b/dggrid4py/igeo7.py
@@ -16,14 +16,14 @@ import pandas as pd
 def decode_z7hex_index(z7_hex_str):
     """
     Decode a Z7 hexadecimal index (provided as hex string).
-    
+
     Format:
     - First 4 bits: base cell number (0-11)
     - Remaining 60 bits: 20 groups of 3 bits each for resolution digits (0-6, 7 for beyond resolution)
-    
+
     Args:
         z7_hex_str (str): Hexadecimal string representing the Z7 cell index
-        
+
     Returns:
         tuple: (base_cell, resolution_digits)
             - base_cell: integer 0-11
@@ -31,17 +31,17 @@ def decode_z7hex_index(z7_hex_str):
     """
     # Convert hex to binary string, ensuring we have full 64 bits
     binary = bin(int(z7_hex_str, 16))[2:].zfill(64)
-    
+
     # Extract base cell (first 4 bits)
     base_cell = int(binary[:4], 2)
-    
+
     # Extract resolution digits (20 groups of 3 bits each)
     resolution_digits = []
     for i in range(20):  # 60 remaining bits = 20 groups of 3 bits
         start = 4 + (i * 3)  # Start after the first 4 bits
         value = int(binary[start:start + 3], 2)
         resolution_digits.append(value)
-    
+
     return base_cell, resolution_digits
 
 
@@ -62,7 +62,7 @@ def z7hex_to_z7string(z7_hex_str):
     return "".join(str_rep)
 
 
-def z7hex_to_z7int( z7_hex_str):
+def z7hex_to_z7int(z7_hex_str):
     # From hex string to integer
     value = int(z7_hex_str, 16)
     return value
@@ -74,6 +74,16 @@ def z7int_to_z7hex(z7_int):
     return hex_back
 
 
+def z7string_to_z7int(z7string):
+    base, digit = z7string[:2], z7string[2:]
+    digit = digit.ljust(20, '7')
+    binary_repr = [np.binary_repr(int(base), width=4)]
+    binary_digit = [np.binary_repr(int(d), width=3) for d in digit]
+    binary_repr += binary_digit
+    binary_repr = ''.join(binary_repr)
+    return int(binary_repr, 2)
+
+
 def get_z7hex_resolution(z7_hex_str):
     """
     Get the resolution of a Z7 cell.
@@ -81,7 +91,7 @@ def get_z7hex_resolution(z7_hex_str):
     Args:
         z7_hex_str (str): Z7 hexadecimal string represention of the cell index
     """
-    base_cell, resolution_digits = decode_z7hex_index(z7_hex_str)    
+    base_cell, resolution_digits = decode_z7hex_index(z7_hex_str)
     return len( list( filter(lambda x: x >= 0 and x < 7, resolution_digits) ) )
 
 
@@ -168,5 +178,5 @@ def apply_convert_z7hex_to_z7string(z7_hex_str):
     z7_res = get_z7hex_resolution(z7_hex_str)
     parent, local_pos, is_center = get_z7hex_local_pos(z7_hex_str)
     return pd.Series([z7_string, z7_res, parent, local_pos, is_center])
-    
+
 


### PR DESCRIPTION
@allixender, 

I implemented the conversion from z7string to z7int. It is an inverse version of `decode_z7hex_index`
The function is now used in several places in `xdggs-dggrid4py` and `pydggsapi` to support zone IDs stored as uint64. I would like to have it merged into the igeo7.py to avoid maintaining it in several libraries. 
Changes. 
  -  `z7string_to_z7int` function in `igeo7.py`

Thanks,
Tik