### PR TITLE
Set shapefile id field length for DGGRIDv8 output

### DIFF
--- a/dggrid4py/dggrid_runner.py
+++ b/dggrid4py/dggrid_runner.py
@@ -166,6 +166,8 @@ DggsOutputCellLabelTypeV8T = Literal[
 ]
 output_cell_label_type_v8 = get_args(DggsOutputCellLabelTypeV8T)
 
+shapefile_id_field_lengths = range(1, 51)
+
 output_extra_fields_v7 = {
     'output_cell_label_type': output_cell_label_type_v7
 }
@@ -180,6 +182,7 @@ output_extra_fields_v8 = {
     'output_cell_label_type': output_cell_label_type_v8,
     'output_hier_ndx_system': output_hier_ndx_systems,
     'output_hier_ndx_form': output_hier_ndx_forms,
+    'shapefile_id_field_length': shapefile_id_field_lengths,
 }
 
 DggsOutputAddressTypeT = DggsOutputAddressTypeV7T | DggsOutputAddressTypeV8T
@@ -872,6 +875,8 @@ class DGGRID(abc.ABC):
                 output_conf['cell_output_type'] in [ 'SHAPEFILE' , 'AIGEN', 'GEOJSON', 'TEXT']
                 and output_conf['cell_output_file_name'] is not None
             ):
+                if self.version == 8 and output_conf['cell_output_type'] == 'SHAPEFILE':
+                    output_conf.setdefault('shapefile_id_field_length', 50)
                 for elem in filter(lambda x: x.startswith('cell_output_') , output_conf.keys()):
                     metafile.append(f"{elem} " + str(output_conf[elem]))
             elif (
@@ -885,6 +890,8 @@ class DGGRID(abc.ABC):
                 metafile.append("cell_output_type NONE")
 
             # check join cell grid params add to metafile
+            for elem in filter(lambda x: x.startswith('shapefile_'), output_conf.keys()):
+                metafile.append(f"{elem} " + str(output_conf[elem]))
 
         # collection output
         if 'collection_output_file_name' in output_conf:

--- a/tests/test_dggrid.py
+++ b/tests/test_dggrid.py
@@ -379,6 +379,62 @@ def test_grid_cell_polygons_from_cellids(monkeypatch):
     }
 
 
+def test_grid_cell_polygons_from_cellids_sets_shapefile_id_field_length(monkeypatch):
+    metafile = []
+    portable_dggrid = DGGRIDv8(
+        executable=dggrid_path,
+        has_gdal=False,
+        tmp_geo_out_legacy=True,
+    )
+
+    def mock_dggrid_grid_gen_run(__metafile):
+        metafile[:] = __metafile
+        return -1  # cause grid_gen to early-exit in error
+
+    monkeypatch.setattr(portable_dggrid, "run", mock_dggrid_grid_gen_run)
+
+    with pytest.raises(ValueError):  # catch and ignore (early-abort "run error")
+        portable_dggrid.grid_cell_polygons_from_cellids(
+            dggs_type="IGEO7",
+            resolution=18,
+            cell_id_list=["023255620345"],
+            clip_subset_type="COARSE_CELLS",
+            clip_cell_res=10,
+            input_address_type="HIERNDX",
+            output_address_type="HIERNDX",
+        )
+
+    meta_args = dict([line.split(" ", 1) for line in metafile])
+    assert "dggrid" in meta_args["clip_region_files"]
+    assert "dggrid" in meta_args["cell_output_file_name"]
+    meta_args.pop("clip_region_files")
+    meta_args.pop("cell_output_file_name")
+    metafile_patched = [f"{key} {val}" for key, val in meta_args.items()]
+
+    assert set(metafile_patched) == {
+        "dggrid_operation GENERATE_GRID",
+        "dggs_type IGEO7",
+        "dggs_proj ISEA",
+        "dggs_aperture 7",
+        "dggs_topology HEXAGON",
+        "dggs_res_spec 18",
+        "precision 7",
+        "cell_output_type SHAPEFILE",
+        "clip_cell_addresses 023255620345",
+        "clip_subset_type COARSE_CELLS",
+        "clip_cell_res 10",
+        "clipper_scale_factor 100000000",
+        "dggs_orient_specify_type SPECIFIED",
+        "dggs_vert0_azimuth 0.0",
+        "dggs_vert0_lat 58.28252559",
+        "dggs_vert0_lon 11.25",
+        "input_address_type HIERNDX",
+        "output_address_type HIERNDX",
+        "shapefile_id_field_length 50",
+        "point_output_type NONE",
+    }
+
+
 def test_cells_for_geo_points(monkeypatch):
     dgapi_grid_transform = dggrid.dgapi_grid_transform
     dgapi_grid_gen = dggrid.dgapi_grid_gen


### PR DESCRIPTION
## Summary
- default DGGRIDv8 shapefile output to `shapefile_id_field_length 50` so high-resolution cell ids fit the DBF id field
- allow callers to pass a validated `shapefile_id_field_length` output extra for DGGRIDv8
- add a mocked metafile regression for the portable shapefile path used by `grid_cell_polygons_from_cellids`

Fixes #21

## Verification
- `DGGRID_PATH=dggrid python -m pytest tests/test_dggrid.py::test_grid_cell_polygons_from_cellids_sets_shapefile_id_field_length -q`
- `DGGRID_PATH=dggrid python -m pytest tests/test_dggrid.py::test_grid_cell_polygons_from_cellids tests/test_clipper_scale_factor.py::test_grid_cell_polygons_from_cellids -q`

## Notes
- `python -m pytest tests/test_dggrid.py tests/test_clipper_scale_factor.py -q` has two environment-dependent failures locally because `DGGRID_PATH` points to a dummy value and no DGGRID executable is available.
- `python -m ruff check dggrid4py/dggrid_runner.py tests/test_dggrid.py` currently reports pre-existing lint debt across `dggrid_runner.py`; I did not broaden this PR into a style cleanup.